### PR TITLE
Fix GraphQL schema introspection issues

### DIFF
--- a/services/graphql-gateway/go.mod
+++ b/services/graphql-gateway/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/99designs/gqlgen v0.17.66
 	github.com/fraser-isbester/federated-gql/gen/go v0.0.0-20250224025919-47a37e4bc4f6
 	github.com/go-chi/chi/v5 v5.2.1
+	github.com/go-chi/cors v1.2.1
 	github.com/gorilla/websocket v1.5.0
 	github.com/vektah/gqlparser/v2 v2.5.22
 )

--- a/services/graphql-gateway/go.sum
+++ b/services/graphql-gateway/go.sum
@@ -18,10 +18,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7cNTs5R6Hk4V2lcmLz2NsG2VnInyNo=
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
-github.com/fraser-isbester/federated-gql/gen/go v0.0.0-20250224025919-47a37e4bc4f6 h1:Ah334tQErAhzKOA4E3jn8V0pBkQpLpsvodUWN9jlQWI=
-github.com/fraser-isbester/federated-gql/gen/go v0.0.0-20250224025919-47a37e4bc4f6/go.mod h1:1PMaHyDa7+eYJ53g9oVR5thYFDnVh48ltTaeE8AdB/w=
 github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
 github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/go-chi/cors v1.2.1 h1:xEC8UT3Rlp2QuWNEr4Fs/c2EAGVKBwy/1vHx3bppil4=
+github.com/go-chi/cors v1.2.1/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=

--- a/services/graphql-gateway/sandbox.go
+++ b/services/graphql-gateway/sandbox.go
@@ -7,14 +7,38 @@ import (
 // RenderApolloSandbox serves the Apollo Sandbox UI
 func RenderApolloSandbox(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
-	w.Write([]byte(`<html><body><div style="width: 100%; height: 100vh;" id='embedded-sandbox'></div>
-<script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js"></script>
-<script>
-  new window.EmbeddedSandbox({
-    target: '#embedded-sandbox',
-    initialEndpoint: 'http://localhost:8080/graphql',
-  });
-</script>
-</body></html>
-	`))
+	w.Write([]byte(`<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Apollo Sandbox</title>
+  <style>
+    body { margin: 0; padding: 0; overflow: hidden; }
+    #sandbox { width: 100%; height: 100vh; }
+  </style>
+</head>
+<body>
+  <div id="sandbox"></div>
+
+  <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js"></script>
+  <script>
+    const sandbox = new window.EmbeddedSandbox({
+      target: '#sandbox',
+      // Ensure it uses relative URL to avoid CORS issues
+      initialEndpoint: '/graphql',
+      includeCookies: true,
+      initialState: {
+        // Enable introspection explicitly in the Explorer
+        explorer: {
+          // Enable schema introspection features
+          introspection: { 
+            enable: true
+          }
+        }
+      }
+    });
+  </script>
+</body>
+</html>`))
 }


### PR DESCRIPTION
- Explicitly enable introspection with extension.Introspection{}
- Add CORS support to allow cross-origin requests for introspection
- Update Apollo Sandbox configuration to request introspection correctly
- Use relative URL path in Apollo Sandbox to avoid CORS issues